### PR TITLE
fix: correct typo in type definition from 'objec' to 'object'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const Tools = [
         data: {
           type: "array",
           items: {
-            type: "objec",
+            type: "object",
             properties: {
               time: { type: "string" },
               value: { type: "number" },


### PR DESCRIPTION
When reviewing this project, I found a spelling error and fixed it immediately.