### PR TITLE
feat: add support for Streamable transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Run the server with your preferred transport option:
 mcp-server-chart --transport sse
 
 # For Streamable transport with custom endpoint
-mcp-server-chart --transport streamable --endpoint /mcp
+mcp-server-chart --transport streamable
 ```
 
 Then you can access the server at:
@@ -100,10 +100,13 @@ You can also use the following CLI options when running the MCP server. Command 
 
 ```plain
 MCP Server Chart CLI
+
 Options:
-  --transport, -t  Specify the transport protocol: "stdio" or "sse" or "streamable" (default: "stdio")
+  --transport, -t  Specify the transport protocol: "stdio", "sse", or "streamable" (default: "stdio")
   --port, -p       Specify the port for SSE or streamable transport (default: 1122)
-  --endpoint, -e   Specify the endpoint for SSE or streamable transport (default: "/sse")
+  --endpoint, -e   Specify the endpoint for the transport:
+                   - For SSE: default is "/sse"
+                   - For streamable: default is "/mcp"
   --help, -h       Show this help message
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ On Window system:
 Also, you can use it on [aliyun](https://bailian.console.aliyun.com/?tab=mcp#/mcp-market/detail/antv-visualization-chart), [modelscope](https://www.modelscope.cn/mcp/servers/@antvis/mcp-server-chart), [glama.ai](https://glama.ai/mcp/servers/@antvis/mcp-server-chart), [smithery.ai](https://smithery.ai/server/@antvis/mcp-server-chart) or others with HTTP, SSE Protocol.
 
 
-## Run with SSE transport
+## Run with SSE or Streamable transport
 
 Install the package globally.
 
@@ -79,13 +79,19 @@ Install the package globally.
 npm install -g @antv/mcp-server-chart
 ```
 
-Run the server with `sse` transport.
+Run the server with your preferred transport option:
 
 ```bash
+# For SSE transport (default endpoint: /sse)
 mcp-server-chart --transport sse
+
+# For Streamable transport with custom endpoint
+mcp-server-chart --transport streamable --endpoint /mcp
 ```
 
-Then you can use the `http://localhost:1122/sse` with `SSE` transport.
+Then you can access the server at:
+- SSE transport: `http://localhost:1122/sse`
+- Streamable transport: `http://localhost:1122/mcp`
 
 
 ## CLI Options
@@ -95,9 +101,9 @@ You can also use the following CLI options when running the MCP server. Command 
 ```plain
 MCP Server Chart CLI
 Options:
-  --transport, -t  Specify the transport protocol: "stdio" or "sse" (default: "stdio")
-  --port, -p       Specify the port for SSE transport (default: 1122)
-  --endpoint, -e   Specify the endpoint for SSE transport (default: "/sse")
+  --transport, -t  Specify the transport protocol: "stdio" or "sse" or "streamable" (default: "stdio")
+  --port, -p       Specify the port for SSE or streamable transport (default: 1122)
+  --endpoint, -e   Specify the endpoint for SSE or streamable transport (default: "/sse")
   --help, -h       Show this help message
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/mcp-server-chart",
   "description": "A Model Context Protocol server for generating charts using AntV, This is a TypeScript-based MCP server that provides chart generation capabilities. It allows you to create various types of charts through MCP tools.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "build/index.js",
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
-import { McpServerChart } from "./server";
+import {
+  runHTTPStreamableServer,
+  runSSEServer,
+  runStdioServer,
+} from "./server";
 
 // Parse command line arguments
 const { values } = parseArgs({
@@ -33,22 +37,24 @@ if (values.help) {
 MCP Server Chart CLI
 
 Options:
-  --transport, -t  Specify the transport protocol: "stdio" or "sse" (default: "stdio")
-  --port, -p       Specify the port for SSE transport (default: 1122)
-  --endpoint, -e   Specify the endpoint for SSE transport (default: "/sse")
+  --transport, -t  Specify the transport protocol: "stdio" or "sse" or "streamable" (default: "stdio")
+  --port, -p       Specify the port for SSE or streamable transport (default: 1122)
+  --endpoint, -e   Specify the endpoint for SSE or streamable transport (default: "/sse")
   --help, -h       Show this help message
   `);
   process.exit(0);
 }
-
-const server = new McpServerChart();
 
 // Run in the specified transport mode
 const transport = values.transport.toLowerCase();
 if (transport === "sse") {
   const port = Number.parseInt(values.port as string, 10);
   const endpoint = values.endpoint as string;
-  server.runSSEServer(endpoint, port).catch(console.error);
+  runSSEServer(endpoint, port).catch(console.error);
+} else if (transport === "streamable") {
+  const port = Number.parseInt(values.port as string, 10);
+  const endpoint = values.endpoint as string;
+  runHTTPStreamableServer(endpoint, port).catch(console.error);
 } else {
-  server.runStdioServer().catch(console.error);
+  runStdioServer().catch(console.error);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const { values } = parseArgs({
     endpoint: {
       type: "string",
       short: "e",
-      default: "/sse",
+      default: "", // We'll handle defaults per transport type
     },
     help: {
       type: "boolean",
@@ -37,9 +37,11 @@ if (values.help) {
 MCP Server Chart CLI
 
 Options:
-  --transport, -t  Specify the transport protocol: "stdio" or "sse" or "streamable" (default: "stdio")
+  --transport, -t  Specify the transport protocol: "stdio", "sse", or "streamable" (default: "stdio")
   --port, -p       Specify the port for SSE or streamable transport (default: 1122)
-  --endpoint, -e   Specify the endpoint for SSE or streamable transport (default: "/sse")
+  --endpoint, -e   Specify the endpoint for the transport:
+                   - For SSE: default is "/sse"
+                   - For streamable: default is "/mcp"
   --help, -h       Show this help message
   `);
   process.exit(0);
@@ -47,13 +49,16 @@ Options:
 
 // Run in the specified transport mode
 const transport = values.transport.toLowerCase();
+
 if (transport === "sse") {
   const port = Number.parseInt(values.port as string, 10);
-  const endpoint = values.endpoint as string;
+  // Use provided endpoint or default to "/sse" for SSE
+  const endpoint = values.endpoint || "/sse";
   runSSEServer(endpoint, port).catch(console.error);
 } else if (transport === "streamable") {
   const port = Number.parseInt(values.port as string, 10);
-  const endpoint = values.endpoint as string;
+  // Use provided endpoint or default to "/mcp" for streamable
+  const endpoint = values.endpoint || "/mcp";
   runHTTPStreamableServer(endpoint, port).catch(console.error);
 } else {
   runStdioServer().catch(console.error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,97 +6,123 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import * as Charts from "./charts";
-import { startSSEMcpServer, startStdioMcpServer } from "./services";
+import {
+  startHTTPStreamableServer,
+  startSSEMcpServer,
+  startStdioMcpServer,
+} from "./services";
 import { ChartTypeMapping, generateChartUrl } from "./utils";
 
 /**
- * MCP Server implementation for chart generation
+ * Creates and configures an MCP server for chart generation.
  */
-export class McpServerChart {
-  private server: Server;
-
-  constructor() {
-    this.server = new Server(
-      {
-        name: "mcp-server-chart",
-        version: "0.3.0",
+export function createServer(): Server {
+  const server = new Server(
+    {
+      name: "mcp-server-chart",
+      version: "0.3.0",
+    },
+    {
+      capabilities: {
+        tools: {},
       },
-      {
-        capabilities: {
-          tools: {},
-        },
-      },
-    );
+    },
+  );
 
-    this.setupToolHandlers();
+  setupToolHandlers(server);
 
-    this.server.onerror = (error) => console.error("[MCP Error]", error);
-    process.on("SIGINT", async () => {
-      await this.server.close();
-      process.exit(0);
-    });
-  }
+  server.onerror = (error) => console.error("[MCP Error]", error);
+  process.on("SIGINT", async () => {
+    await server.close();
+    process.exit(0);
+  });
 
-  private setupToolHandlers() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: Object.values(Charts).map((chart) => chart.tool),
-    }));
+  return server;
+}
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const chartType =
-        ChartTypeMapping[request.params.name as keyof typeof ChartTypeMapping];
+/**
+ * Sets up tool handlers for the MCP server.
+ */
+function setupToolHandlers(server: Server): void {
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: Object.values(Charts).map((chart) => chart.tool),
+  }));
 
-      if (!chartType) {
-        throw new McpError(
-          ErrorCode.MethodNotFound,
-          `Unknown tool: ${request.params.name}.`,
-        );
-      }
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const chartType =
+      ChartTypeMapping[request.params.name as keyof typeof ChartTypeMapping];
 
-      try {
-        // Validate input using Zod before sending to API
-        const args = request.params.arguments || {};
+    if (!chartType) {
+      throw new McpError(
+        ErrorCode.MethodNotFound,
+        `Unknown tool: ${request.params.name}.`,
+      );
+    }
 
-        // Select the appropriate schema based on the chart type
-        const schema = Charts[chartType].schema;
+    try {
+      // Validate input using Zod before sending to API.
+      const args = request.params.arguments || {};
 
-        if (schema) {
-          // Use safeParse instead of parse and try-catch
-          const result = schema.safeParse(args);
-          if (!result.success) {
-            throw new McpError(
-              ErrorCode.InvalidParams,
-              `Invalid parameters: ${result.error.message}`,
-            );
-          }
+      // Select the appropriate schema based on the chart type.
+      const schema = Charts[chartType].schema;
+
+      if (schema) {
+        // Use safeParse instead of parse and try-catch.
+        const result = schema.safeParse(args);
+        if (!result.success) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `Invalid parameters: ${result.error.message}`,
+          );
         }
-
-        const url = await generateChartUrl(chartType, args);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: url,
-            },
-          ],
-        };
-        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-      } catch (error: any) {
-        if (error instanceof McpError) throw error;
-        throw new McpError(
-          ErrorCode.InternalError,
-          `Failed to generate chart: ${error?.message || "Unknown error."}`,
-        );
       }
-    });
-  }
 
-  async runStdioServer() {
-    await startStdioMcpServer(this.server);
-  }
+      const url = await generateChartUrl(chartType, args);
 
-  async runSSEServer(endpoint = "/sse", port = 1122) {
-    await startSSEMcpServer(this.server, endpoint, port);
-  }
+      return {
+        content: [
+          {
+            type: "text",
+            text: url,
+          },
+        ],
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    } catch (error: any) {
+      if (error instanceof McpError) throw error;
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to generate chart: ${error?.message || "Unknown error."}`,
+      );
+    }
+  });
+}
+
+/**
+ * Runs the server with stdio transport.
+ */
+export async function runStdioServer(): Promise<void> {
+  const server = createServer();
+  await startStdioMcpServer(server);
+}
+
+/**
+ * Runs the server with SSE transport.
+ */
+export async function runSSEServer(
+  endpoint = "/sse",
+  port = 1122,
+): Promise<void> {
+  const server = createServer();
+  await startSSEMcpServer(server, endpoint, port);
+}
+
+/**
+ * Runs the server with HTTP streamable transport.
+ */
+export async function runHTTPStreamableServer(
+  endpoint = "/mcp",
+  port = 1122,
+): Promise<void> {
+  await startHTTPStreamableServer(createServer, endpoint, port);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: "mcp-server-chart",
-      version: "0.3.0",
+      version: "0.4.0",
     },
     {
       capabilities: {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,3 @@
 export { startStdioMcpServer } from "./stdio";
 export { startSSEMcpServer } from "./sse";
+export { startHTTPStreamableServer } from "./streamable";

--- a/src/services/sse.ts
+++ b/src/services/sse.ts
@@ -1,6 +1,7 @@
-import http from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { type RequestHandlers, createBaseHttpServer } from "../utils";
 
 export const startSSEMcpServer = async (
   server: Server,
@@ -9,44 +10,20 @@ export const startSSEMcpServer = async (
 ): Promise<void> => {
   const activeTransports: Record<string, SSEServerTransport> = {};
 
-  const httpServer = http.createServer(async (req, res) => {
-    if (req.headers.origin) {
-      try {
-        const origin = new URL(req.headers.origin);
-
-        res.setHeader("Access-Control-Allow-Origin", origin.origin);
-        res.setHeader("Access-Control-Allow-Credentials", "true");
-        res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-        res.setHeader("Access-Control-Allow-Headers", "*");
-      } catch (error) {
-        console.error("Error parsing origin:", error);
-      }
-    }
-
-    if (req.method === "OPTIONS") {
-      res.writeHead(204).end();
-      return;
-    }
-
+  // Define the request handler for SSE-specific logic
+  const handleRequest: RequestHandlers["handleRequest"] = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+  ) => {
     if (!req.url) {
       res.writeHead(400).end("No URL");
       return;
     }
 
-    if (req.method === "GET" && req.url === "/health") {
-      res.writeHead(200, { "Content-Type": "text/plain" }).end("OK");
-      return;
-    }
+    const reqUrl = new URL(req.url, "http://localhost");
 
-    if (req.method === "GET" && req.url === "/ping") {
-      res.writeHead(200).end("pong");
-      return;
-    }
-
-    if (
-      req.method === "GET" &&
-      new URL(req.url, "http://localhost").pathname === endpoint
-    ) {
+    // Handle GET requests to the SSE endpoint
+    if (req.method === "GET" && reqUrl.pathname === endpoint) {
       const transport = new SSEServerTransport("/messages", res);
 
       activeTransports[transport.sessionId] = transport;
@@ -84,6 +61,7 @@ export const startSSEMcpServer = async (
       return;
     }
 
+    // Handle POST requests to the messages endpoint
     if (req.method === "POST" && req.url?.startsWith("/messages")) {
       const sessionId = new URL(
         req.url,
@@ -92,7 +70,6 @@ export const startSSEMcpServer = async (
 
       if (!sessionId) {
         res.writeHead(400).end("No sessionId");
-
         return;
       }
 
@@ -101,46 +78,30 @@ export const startSSEMcpServer = async (
 
       if (!activeTransport) {
         res.writeHead(400).end("No active transport");
-
         return;
       }
 
       await activeTransport.handlePostMessage(req, res);
-
       return;
     }
-  });
 
-  // clean up server when process exit
+    // If we reach here, no handler matched
+    res.writeHead(404).end("Not found");
+  };
+
+  // Custom cleanup for SSE server
   const cleanup = () => {
-    console.log("\nClosing SSE server...");
-    // close all active transports
+    // Close all active transports
     for (const transport of Object.values(activeTransports)) {
       transport.close();
     }
-
     server.close();
-    httpServer.close(() => {
-      console.log("SSE server closed");
-      process.exit(0);
-    });
   };
 
-  process.on("SIGINT", cleanup); // Ctrl+C
-  process.on("SIGTERM", cleanup); // kill command
-
-  httpServer.listen(port, () => {
-    // Format the URLs as clickable links in the terminal
-    const serverUrl = `http://localhost:${port}${endpoint}`;
-    const healthUrl = `http://localhost:${port}/health`;
-    const pingUrl = `http://localhost:${port}/ping`;
-
-    // Use ANSI escape codes to make the URLs clickable in most modern terminals
-    console.log(
-      `MCP Server Chart running on SSE at: \x1b[32m\u001B[4m${serverUrl}\u001B[0m\x1b[0m`,
-    );
-    console.log("\nTest endpoints:");
-    console.log(`• Health check: \u001B[4m${healthUrl}\u001B[0m`);
-    console.log(`• Ping test: \u001B[4m${pingUrl}\u001B[0m`);
+  // Create the HTTP server using our factory
+  createBaseHttpServer(port, endpoint, {
+    handleRequest,
+    cleanup,
+    serverType: "SSE Server",
   });
 };

--- a/src/services/sse.ts
+++ b/src/services/sse.ts
@@ -5,7 +5,7 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 export const startSSEMcpServer = async (
   server: Server,
   endpoint = "/sse",
-  port = 9528,
+  port = 1122,
 ): Promise<void> => {
   const activeTransports: Record<string, SSEServerTransport> = {};
 
@@ -114,6 +114,12 @@ export const startSSEMcpServer = async (
   // clean up server when process exit
   const cleanup = () => {
     console.log("\nClosing SSE server...");
+    // close all active transports
+    for (const transport of Object.values(activeTransports)) {
+      transport.close();
+    }
+
+    server.close();
     httpServer.close(() => {
       console.log("SSE server closed");
       process.exit(0);

--- a/src/services/stdio.ts
+++ b/src/services/stdio.ts
@@ -4,4 +4,5 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 export async function startStdioMcpServer(server: Server): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  console.log("MCP Server Chart running on stdio");
 }

--- a/src/services/stdio.ts
+++ b/src/services/stdio.ts
@@ -4,5 +4,5 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 export async function startStdioMcpServer(server: Server): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log("MCP Server Chart running on stdio");
+  console.error("MCP Server Chart running on stdio");
 }

--- a/src/services/stdio.ts
+++ b/src/services/stdio.ts
@@ -4,5 +4,4 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 export async function startStdioMcpServer(server: Server): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("MCP Server Chart running on stdio");
 }

--- a/src/services/streamable.ts
+++ b/src/services/streamable.ts
@@ -1,0 +1,268 @@
+import http from "node:http";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  type EventStore,
+  StreamableHTTPServerTransport,
+} from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { InMemoryEventStore } from "../utils";
+
+import { randomUUID } from "node:crypto";
+
+export const startHTTPStreamableServer = async (
+  createServer: () => Server,
+  endpoint = "/mcp",
+  port = 1122,
+  eventStore: EventStore = new InMemoryEventStore(),
+): Promise<void> => {
+  const activeTransports: Record<
+    string,
+    {
+      server: Server;
+      transport: StreamableHTTPServerTransport;
+    }
+  > = {};
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.headers.origin) {
+      try {
+        const origin = new URL(req.headers.origin);
+
+        res.setHeader("Access-Control-Allow-Origin", origin.origin);
+        res.setHeader("Access-Control-Allow-Credentials", "true");
+        res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+        res.setHeader("Access-Control-Allow-Headers", "*");
+      } catch (error) {
+        console.error("Error parsing origin:", error);
+      }
+    }
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204).end();
+      return;
+    }
+
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "text/plain" }).end("OK");
+      return;
+    }
+
+    if (req.method === "GET" && req.url === "/ping") {
+      res.writeHead(200).end("pong");
+      return;
+    }
+
+    if (!req.url) {
+      res.writeHead(400).end("No URL");
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      new URL(req.url, "http://localhost").pathname === endpoint
+    ) {
+      try {
+        const sessionId = Array.isArray(req.headers["mcp-session-id"])
+          ? req.headers["mcp-session-id"][0]
+          : req.headers["mcp-session-id"];
+        let transport: StreamableHTTPServerTransport;
+
+        let server: Server;
+
+        const body = await getBody(req);
+
+        /**
+         * diagram: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#sequence-diagram.
+         */
+        // 1. If the sessionId is provided and the server is already created, use the existing transport and server.
+        if (sessionId && activeTransports[sessionId]) {
+          transport = activeTransports[sessionId].transport;
+          server = activeTransports[sessionId].server;
+
+          // 2. If the sessionId is not provided and the request is an initialize request, create a new transport for the session.
+        } else if (!sessionId && isInitializeRequest(body)) {
+          transport = new StreamableHTTPServerTransport({
+            // use the event store to store the events to replay on reconnect.
+            // more details: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery.
+            eventStore: eventStore || new InMemoryEventStore(),
+            onsessioninitialized: (_sessionId: string) => {
+              // add only when the id Sesison id is generated.
+              activeTransports[_sessionId] = {
+                server,
+                transport,
+              };
+            },
+            sessionIdGenerator: randomUUID,
+          });
+
+          // Handle the server close event.
+          transport.onclose = async () => {
+            const sid = transport.sessionId;
+            if (sid && activeTransports[sid]) {
+              try {
+                await server?.close();
+              } catch (error) {
+                console.error("Error closing server:", error);
+              }
+
+              // delete used transport and server to avoid memory leak.
+              delete activeTransports[sid];
+            }
+          };
+
+          // Create the server
+          try {
+            server = createServer();
+          } catch (error) {
+            if (error instanceof Response) {
+              res.writeHead(error.status).end(error.statusText);
+              return;
+            }
+            res.writeHead(500).end("Error creating server");
+            return;
+          }
+
+          server.connect(transport);
+
+          await transport.handleRequest(req, res, body);
+          return;
+        } else {
+          // Error if the server is not created but the request is not an initialize request.
+          res.setHeader("Content-Type", "application/json");
+          res.writeHead(400).end(
+            JSON.stringify({
+              error: {
+                code: -32000,
+                message: "Bad Request: No valid session ID provided",
+              },
+              id: null,
+              jsonrpc: "2.0",
+            }),
+          );
+
+          return;
+        }
+
+        // Handle the request if the server is already created.
+        await transport.handleRequest(req, res, body);
+      } catch (error) {
+        console.error("Error handling request:", error);
+        res.setHeader("Content-Type", "application/json");
+        res.writeHead(500).end(
+          JSON.stringify({
+            error: { code: -32603, message: "Internal Server Error" },
+            id: null,
+            jsonrpc: "2.0",
+          }),
+        );
+      }
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      new URL(req.url, "http://localhost").pathname === endpoint
+    ) {
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      const activeTransport:
+        | {
+            server: Server;
+            transport: StreamableHTTPServerTransport;
+          }
+        | undefined = sessionId ? activeTransports[sessionId] : undefined;
+
+      if (!sessionId) {
+        res.writeHead(400).end("No sessionId");
+        return;
+      }
+
+      if (!activeTransport) {
+        res.writeHead(400).end("No active transport");
+        return;
+      }
+
+      const lastEventId = req.headers["last-event-id"] as string | undefined;
+      if (lastEventId) {
+        console.log(`Client reconnecting with Last-Event-ID: ${lastEventId}`);
+      } else {
+        console.log(`Establishing new SSE stream for session ${sessionId}`);
+      }
+
+      await activeTransport.transport.handleRequest(req, res);
+      return;
+    }
+
+    if (
+      req.method === "DELETE" &&
+      new URL(req.url, "http://localhost").pathname === endpoint
+    ) {
+      console.log("received delete request");
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      if (!sessionId) {
+        res.writeHead(400).end("Invalid or missing sessionId");
+        return;
+      }
+
+      console.log("received delete request for session", sessionId);
+
+      const transport = activeTransports[sessionId].transport;
+      if (!transport) {
+        res.writeHead(400).end("No active transport");
+        return;
+      }
+
+      try {
+        await transport.handleRequest(req, res);
+      } catch (error) {
+        console.error("Error handling delete request:", error);
+        res.writeHead(500).end("Error handling delete request");
+      }
+
+      return;
+    }
+  });
+
+  const cleanup = () => {
+    console.log("\nClosing Streamable server...");
+    for (const { server, transport } of Object.values(activeTransports)) {
+      transport.close();
+      server.close();
+    }
+
+    httpServer.close(() => {
+      console.log("Streamable server closed");
+      process.exit(0);
+    });
+  };
+
+  process.on("SIGINT", cleanup); // Ctrl+C
+  process.on("SIGTERM", cleanup); // kill command
+
+  httpServer.listen(port, () => {
+    const serverUrl = `http://localhost:${port}${endpoint}`;
+    const healthUrl = `http://localhost:${port}/health`;
+    const pingUrl = `http://localhost:${port}/ping`;
+
+    console.log(
+      `Streamable server running on: \x1b[32m\u001B[4m${serverUrl}\u001B[0m\x1b[0m`,
+    );
+    console.log("\nTest endpoints:");
+    console.log(`• Health check: \u001B[4m${healthUrl}\u001B[0m`);
+    console.log(`• Ping test: \u001B[4m${pingUrl}\u001B[0m`);
+  });
+};
+
+function getBody(request: http.IncomingMessage) {
+  return new Promise((resolve) => {
+    const bodyParts: Buffer[] = [];
+    let body: string;
+    request
+      .on("data", (chunk) => {
+        bodyParts.push(chunk);
+      })
+      .on("end", () => {
+        body = Buffer.concat(bodyParts).toString();
+        resolve(JSON.parse(body));
+      });
+  });
+}

--- a/src/utils/InMemoryEventStore.ts
+++ b/src/utils/InMemoryEventStore.ts
@@ -1,5 +1,6 @@
 /**
  * This is a copy of the InMemoryEventStore from the typescript-sdk.
+ * reference: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/examples/shared/inMemoryEventStore.ts
  */
 
 import type { EventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -12,8 +13,33 @@ import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
  * see more details: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery.
  */
 export class InMemoryEventStore implements EventStore {
-  private events: Map<string, { message: JSONRPCMessage; streamId: string }> =
+  private events: Map<string, { streamId: string; message: JSONRPCMessage }> =
     new Map();
+
+  /**
+   * Generates a unique event ID for a given stream ID
+   */
+  private generateEventId(streamId: string): string {
+    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+  }
+
+  /**
+   * Extracts the stream ID from an event ID
+   */
+  private getStreamIdFromEventId(eventId: string): string {
+    const parts = eventId.split("_");
+    return parts.length > 0 ? parts[0] : "";
+  }
+
+  /**
+   * Stores an event with a generated event ID
+   * Implements EventStore.storeEvent
+   */
+  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+    const eventId = this.generateEventId(streamId);
+    this.events.set(eventId, { streamId, message });
+    return eventId;
+  }
 
   /**
    * Replays events that occurred after a specific event ID
@@ -44,7 +70,7 @@ export class InMemoryEventStore implements EventStore {
 
     for (const [
       eventId,
-      { message, streamId: eventStreamId },
+      { streamId: eventStreamId, message },
     ] of sortedEvents) {
       // Only include events from the same stream
       if (eventStreamId !== streamId) {
@@ -62,30 +88,5 @@ export class InMemoryEventStore implements EventStore {
       }
     }
     return streamId;
-  }
-
-  /**
-   * Stores an event with a generated event ID
-   * Implements EventStore.storeEvent
-   */
-  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
-    const eventId = this.generateEventId(streamId);
-    this.events.set(eventId, { message, streamId });
-    return eventId;
-  }
-
-  /**
-   * Generates a unique event ID for a given stream ID
-   */
-  private generateEventId(streamId: string): string {
-    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
-  }
-
-  /**
-   * Extracts the stream ID from an event ID
-   */
-  private getStreamIdFromEventId(eventId: string): string {
-    const parts = eventId.split("_");
-    return parts.length > 0 ? parts[0] : "";
   }
 }

--- a/src/utils/InMemoryEventStore.ts
+++ b/src/utils/InMemoryEventStore.ts
@@ -1,0 +1,91 @@
+/**
+ * This is a copy of the InMemoryEventStore from the typescript-sdk.
+ */
+
+import type { EventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Simple in-memory implementation of the EventStore interface for resumability.
+ * This is primarily intended for examples and testing, not for production use.
+ * where a persistent storage solution would be more appropriate.
+ * see more details: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery.
+ */
+export class InMemoryEventStore implements EventStore {
+  private events: Map<string, { message: JSONRPCMessage; streamId: string }> =
+    new Map();
+
+  /**
+   * Replays events that occurred after a specific event ID
+   * Implements EventStore.replayEventsAfter
+   */
+  async replayEventsAfter(
+    lastEventId: string,
+    {
+      send,
+    }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> },
+  ): Promise<string> {
+    if (!lastEventId || !this.events.has(lastEventId)) {
+      return "";
+    }
+
+    // Extract the stream ID from the event ID
+    const streamId = this.getStreamIdFromEventId(lastEventId);
+    if (!streamId) {
+      return "";
+    }
+
+    let foundLastEvent = false;
+
+    // Sort events by eventId for chronological ordering
+    const sortedEvents = [...this.events.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+
+    for (const [
+      eventId,
+      { message, streamId: eventStreamId },
+    ] of sortedEvents) {
+      // Only include events from the same stream
+      if (eventStreamId !== streamId) {
+        continue;
+      }
+
+      // Start sending events after we find the lastEventId
+      if (eventId === lastEventId) {
+        foundLastEvent = true;
+        continue;
+      }
+
+      if (foundLastEvent) {
+        await send(eventId, message);
+      }
+    }
+    return streamId;
+  }
+
+  /**
+   * Stores an event with a generated event ID
+   * Implements EventStore.storeEvent
+   */
+  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+    const eventId = this.generateEventId(streamId);
+    this.events.set(eventId, { message, streamId });
+    return eventId;
+  }
+
+  /**
+   * Generates a unique event ID for a given stream ID
+   */
+  private generateEventId(streamId: string): string {
+    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+  }
+
+  /**
+   * Extracts the stream ID from an event ID
+   */
+  private getStreamIdFromEventId(eventId: string): string {
+    const parts = eventId.split("_");
+    return parts.length > 0 ? parts[0] : "";
+  }
+}

--- a/src/utils/getBody.ts
+++ b/src/utils/getBody.ts
@@ -1,0 +1,16 @@
+import type { IncomingMessage } from "node:http";
+
+export function getBody(request: IncomingMessage) {
+  return new Promise((resolve) => {
+    const bodyParts: Buffer[] = [];
+    let body: string;
+    request
+      .on("data", (chunk) => {
+        bodyParts.push(chunk);
+      })
+      .on("end", () => {
+        body = Buffer.concat(bodyParts).toString();
+        resolve(JSON.parse(body));
+      });
+  });
+}

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -1,0 +1,149 @@
+import http from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * Interface for request handlers that will be passed to the server factory
+ */
+export interface RequestHandlers {
+  /**
+   * Main handler for HTTP requests
+   */
+  handleRequest: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+
+  /**
+   * Custom cleanup function to be called when the server is shutting down
+   */
+  cleanup?: () => void;
+
+  /**
+   * Server type name for logging purposes
+   */
+  serverType: string;
+}
+
+/**
+ * Handles CORS headers for incoming requests
+ */
+function handleCORS(req: IncomingMessage, res: ServerResponse): void {
+  if (req.headers.origin) {
+    try {
+      const origin = new URL(req.headers.origin as string);
+      res.setHeader("Access-Control-Allow-Origin", origin.origin);
+      res.setHeader("Access-Control-Allow-Credentials", "true");
+      res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "*");
+    } catch (error) {
+      console.error("Error parsing origin:", error);
+    }
+  }
+}
+
+/**
+ * Handles common endpoints like health check and ping
+ * @returns true if the request was handled, false otherwise
+ */
+function handleCommonEndpoints(
+  req: IncomingMessage,
+  res: ServerResponse,
+): boolean {
+  if (!req.url) {
+    res.writeHead(400).end("No URL");
+    return true;
+  }
+
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "text/plain" }).end("OK");
+    return true;
+  }
+
+  if (req.method === "GET" && req.url === "/ping") {
+    res.writeHead(200).end("pong");
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Sets up signal handlers for graceful shutdown
+ */
+function setupCleanupHandlers(
+  httpServer: http.Server,
+  customCleanup?: () => void,
+): void {
+  const cleanup = () => {
+    console.log("\nClosing server...");
+
+    // Execute custom cleanup if provided
+    if (customCleanup) customCleanup();
+
+    httpServer.close(() => {
+      console.log("Server closed");
+      process.exit(0);
+    });
+  };
+
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+}
+
+/**
+ * Logs server startup information with formatted URLs
+ */
+function logServerStartup(
+  serverType: string,
+  port: number,
+  endpoint: string,
+): void {
+  const serverUrl = `http://localhost:${port}${endpoint}`;
+  const healthUrl = `http://localhost:${port}/health`;
+  const pingUrl = `http://localhost:${port}/ping`;
+
+  console.log(
+    `${serverType} running on: \x1b[32m\u001B[4m${serverUrl}\u001B[0m\x1b[0m`,
+  );
+  console.log("\nTest endpoints:");
+  console.log(`• Health check: \u001B[4m${healthUrl}\u001B[0m`);
+  console.log(`• Ping test: \u001B[4m${pingUrl}\u001B[0m`);
+}
+
+/**
+ * Creates a base HTTP server with common functionality
+ */
+export function createBaseHttpServer(
+  port: number,
+  endpoint: string,
+  handlers: RequestHandlers,
+): http.Server {
+  const httpServer = http.createServer(async (req, res) => {
+    // Handle CORS for all requests
+    handleCORS(req, res);
+
+    // Handle OPTIONS requests
+    if (req.method === "OPTIONS") {
+      res.writeHead(204).end();
+      return;
+    }
+
+    // Handle common endpoints like health and ping
+    if (handleCommonEndpoints(req, res)) return;
+
+    // Pass remaining requests to the specific handler
+    try {
+      await handlers.handleRequest(req, res);
+    } catch (error) {
+      console.error(`Error in ${handlers.serverType} request handler:`, error);
+      res.writeHead(500).end("Internal Server Error");
+    }
+  });
+
+  // Set up cleanup handlers
+  setupCleanupHandlers(httpServer, handlers.cleanup);
+
+  // Start listening and log server info
+  httpServer.listen(port, () => {
+    logServerStartup(handlers.serverType, port, endpoint);
+  });
+
+  return httpServer;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,5 @@ export { ChartTypeMapping } from "./constants";
 export { generateChartUrl } from "./generate";
 export { zodToJsonSchema } from "./schema";
 export { InMemoryEventStore } from "./InMemoryEventStore";
+export { getBody } from "./getBody";
+export { createBaseHttpServer, type RequestHandlers } from "./httpServer";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { ChartTypeMapping } from "./constants";
 export { generateChartUrl } from "./generate";
 export { zodToJsonSchema } from "./schema";
+export { InMemoryEventStore } from "./InMemoryEventStore";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
- fixed: https://github.com/antvis/mcp-server-chart/issues/24
- src/server.ts 文件由类格式改为函数式，实现 createServer 函数。原因：server 在 streamable 模式下要和 transport 绑定。参考 mcp-proxy server 设计。
- src/services/stdio.ts 添加 console.log ，否则 stdio 启动后，终端没有任何信息提示是否启动成功。
- src/services/streamable.ts 代码参考：https://github.com/punkpeye/mcp-proxy/blob/main/src/startHTTPStreamServer.ts
- src/utils/InMemoryEventStore.ts 实现简易的 eventStore ，生产环境需要永久化存储（db），提供可恢复性和重新交付能力，简易版存在内存中。https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery