### PR TITLE
feat: add `theme` in chart schema, add  `academy` theme

### DIFF
--- a/__tests__/charts/area.json
+++ b/__tests__/charts/area.json
@@ -24,6 +24,12 @@
         "default": false,
         "description": "Whether stacking is enabled. When enabled, area charts require a 'group' field in the data."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/bar.json
+++ b/__tests__/charts/bar.json
@@ -29,6 +29,12 @@
         "default": true,
         "description": "Whether stacking is enabled. When enabled, bar charts require a 'group' field in the data. When `stack` is true, `group` should be false."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/column.json
+++ b/__tests__/charts/column.json
@@ -29,6 +29,12 @@
         "default": false,
         "description": "Whether stacking is enabled. When enabled, column charts require a 'group' field in the data. When `stack` is true, `group` should be false."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/dual-axes.json
+++ b/__tests__/charts/dual-axes.json
@@ -5,6 +5,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/fishbone-diagram.json
+++ b/__tests__/charts/fishbone-diagram.json
@@ -29,6 +29,12 @@
         "required": ["name"],
         "description": "Data for fishbone diagram chart, such as, { name: 'main topic', children: [{ name: 'topic 1', children: [{ name: 'subtopic 1-1' }] }."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/flow-diagram.json
+++ b/__tests__/charts/flow-diagram.json
@@ -35,6 +35,12 @@
         "required": ["nodes", "edges"],
         "description": "Data for flow diagram chart, such as, { nodes: [{ name: 'node1' }, { name: 'node2' }], edges: [{ source: 'node1', target: 'node2', name: 'edge1' }] }."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/histogram.json
+++ b/__tests__/charts/histogram.json
@@ -28,6 +28,12 @@
         "default": null,
         "description": "Number of intervals to define the number of intervals in a histogram."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/line.json
+++ b/__tests__/charts/line.json
@@ -23,6 +23,12 @@
         "default": false,
         "description": "Whether stacking is enabled. When enabled, line charts require a 'group' field in the data."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/mind-map.json
+++ b/__tests__/charts/mind-map.json
@@ -31,6 +31,12 @@
         "required": ["name"],
         "description": "Data for mind map chart, such as, { name: 'main topic', children: [{ name: 'topic 1', children: [{ name:'subtopic 1-1' }] }."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/network-graph.json
+++ b/__tests__/charts/network-graph.json
@@ -35,6 +35,12 @@
         "required": ["nodes", "edges"],
         "description": "Data for network graph chart, such as, { nodes: [{ name: 'node1' }, { name: 'node2' }], edges: [{ source: 'node1', target: 'node2', name: 'edge1' }] }"
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/pie.json
+++ b/__tests__/charts/pie.json
@@ -23,6 +23,12 @@
         "description": "Set the innerRadius of pie chart, the value between 0 and 1. Set the pie chart as a donut chart. Set the value to 0.6 or number in [0 ,1] to enable it.",
         "default": 0
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/radar.json
+++ b/__tests__/charts/radar.json
@@ -19,6 +19,12 @@
         },
         "description": "Data for radar chart, such as, [{ name: 'Design', value: 70 }]."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/scatter.json
+++ b/__tests__/charts/scatter.json
@@ -18,6 +18,12 @@
         },
         "description": "Data for scatter chart, such as, [{ x: 10, y: 15 }]."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/treemap.json
+++ b/__tests__/charts/treemap.json
@@ -22,6 +22,12 @@
         },
         "description": "Data for treemap chart, such as, [{ name: 'Design', value: 70, children: [{ name: 'Tech', value: 20 }] }]."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/__tests__/charts/word-cloud.json
+++ b/__tests__/charts/word-cloud.json
@@ -18,6 +18,12 @@
         },
         "description": "Data for word cloud chart, such as, [{ value: '4.272', text: '形成' }]."
       },
+      "theme": {
+        "default": "default",
+        "description": "Set the theme for the chart, optional, default is 'default'.",
+        "enum": ["default", "academy"],
+        "type": "string"
+      },
       "width": {
         "type": "number",
         "description": "Set the width of chart, default is 600.",

--- a/src/charts/area.ts
+++ b/src/charts/area.ts
@@ -4,6 +4,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -28,6 +29,7 @@ const schema = z.object({
     .describe(
       "Whether stacking is enabled. When enabled, area charts require a 'group' field in the data.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/bar.ts
+++ b/src/charts/bar.ts
@@ -4,6 +4,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -37,6 +38,7 @@ const schema = z.object({
     .describe(
       "Whether stacking is enabled. When enabled, bar charts require a 'group' field in the data. When `stack` is true, `group` should be false.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/base.ts
+++ b/src/charts/base.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 
 // Define Zod schemas for base configuration properties
+export const ThemeSchema = z
+  .enum(["default", "academy"])
+  .optional()
+  .default("default")
+  .describe("Set the theme for the chart, optional, default is 'default'.");
+
 export const WidthSchema = z
   .number()
   .optional()

--- a/src/charts/column.ts
+++ b/src/charts/column.ts
@@ -4,6 +4,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -37,6 +38,7 @@ const schema = z.object({
     .describe(
       "Whether stacking is enabled. When enabled, column charts require a 'group' field in the data. When `stack` is true, `group` should be false.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/dual-axes.ts
+++ b/src/charts/dual-axes.ts
@@ -3,6 +3,7 @@ import { zodToJsonSchema } from "../utils";
 import {
   AxisXTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -35,6 +36,7 @@ const schema = z.object({
   series: z
     .array(DualAxesSeriesSchema)
     .nonempty({ message: "Dual axes chart series cannot be empty." }),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/fishbone-diagram.ts
+++ b/src/charts/fishbone-diagram.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { HeightSchema, WidthSchema } from "./base";
+import { HeightSchema, ThemeSchema, WidthSchema } from "./base";
 
 // Fishbone node schema
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -16,6 +16,7 @@ const schema = z.object({
   data: FishboneNodeSchema.describe(
     "Data for fishbone diagram chart, such as, { name: 'main topic', children: [{ name: 'topic 1', children: [{ name: 'subtopic 1-1' }] }.",
   ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
 });

--- a/src/charts/flow-diagram.ts
+++ b/src/charts/flow-diagram.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { EdgeSchema, HeightSchema, NodeSchema, WidthSchema } from "./base";
+import {
+  EdgeSchema,
+  HeightSchema,
+  NodeSchema,
+  ThemeSchema,
+  WidthSchema,
+} from "./base";
 
 // Flow diagram input schema
 const schema = z.object({
@@ -14,6 +20,7 @@ const schema = z.object({
     .describe(
       "Data for flow diagram chart, such as, { nodes: [{ name: 'node1' }, { name: 'node2' }], edges: [{ source: 'node1', target: 'node2', name: 'edge1' }] }.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
 });

--- a/src/charts/histogram.ts
+++ b/src/charts/histogram.ts
@@ -4,6 +4,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -21,6 +22,7 @@ const schema = z.object({
     .describe(
       "Number of intervals to define the number of intervals in a histogram.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/line.ts
+++ b/src/charts/line.ts
@@ -4,6 +4,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -27,6 +28,7 @@ const schema = z.object({
     .describe(
       "Whether stacking is enabled. When enabled, line charts require a 'group' field in the data.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/mind-map.ts
+++ b/src/charts/mind-map.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { HeightSchema, WidthSchema } from "./base";
+import { HeightSchema, ThemeSchema, WidthSchema } from "./base";
 
 // Mind map node schema
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -16,6 +16,7 @@ const schema = z.object({
   data: MindMapNodeSchema.describe(
     "Data for mind map chart, such as, { name: 'main topic', children: [{ name: 'topic 1', children: [{ name:'subtopic 1-1' }] }.",
   ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
 });

--- a/src/charts/network-graph.ts
+++ b/src/charts/network-graph.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { EdgeSchema, HeightSchema, NodeSchema, WidthSchema } from "./base";
+import {
+  EdgeSchema,
+  HeightSchema,
+  NodeSchema,
+  ThemeSchema,
+  WidthSchema,
+} from "./base";
 
 // Network graph input schema
 const schema = z.object({
@@ -14,6 +20,7 @@ const schema = z.object({
     .describe(
       "Data for network graph chart, such as, { nodes: [{ name: 'node1' }, { name: 'node2' }], edges: [{ source: 'node1', target: 'node2', name: 'edge1' }] }",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
 });

--- a/src/charts/pie.ts
+++ b/src/charts/pie.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { HeightSchema, TitleSchema, WidthSchema } from "./base";
+import { HeightSchema, ThemeSchema, TitleSchema, WidthSchema } from "./base";
 
 // Pie chart data schema
 const data = z.object({
@@ -22,6 +22,7 @@ const schema = z.object({
     .describe(
       "Set the innerRadius of pie chart, the value between 0 and 1. Set the pie chart as a donut chart. Set the value to 0.6 or number in [0 ,1] to enable it.",
     ),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/radar.ts
+++ b/src/charts/radar.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { HeightSchema, TitleSchema, WidthSchema } from "./base";
+import { HeightSchema, ThemeSchema, TitleSchema, WidthSchema } from "./base";
 
 // Radar chart data schema
 const data = z.object({
@@ -15,6 +15,7 @@ const schema = z.object({
     .array(data)
     .describe("Data for radar chart, such as, [{ name: 'Design', value: 70 }].")
     .nonempty({ message: "Radar chart data cannot be empty." }),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/scatter.ts
+++ b/src/charts/scatter.ts
@@ -4,6 +4,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  ThemeSchema,
   TitleSchema,
   WidthSchema,
 } from "./base";
@@ -20,6 +21,7 @@ const schema = z.object({
     .array(data)
     .describe("Data for scatter chart, such as, [{ x: 10, y: 15 }].")
     .nonempty({ message: "Scatter chart data cannot be empty." }),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/treemap.ts
+++ b/src/charts/treemap.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { HeightSchema, TitleSchema, WidthSchema } from "./base";
+import { HeightSchema, ThemeSchema, TitleSchema, WidthSchema } from "./base";
 
 // Define recursive schema for hierarchical data
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -20,6 +20,7 @@ const schema = z.object({
       "Data for treemap chart, such as, [{ name: 'Design', value: 70, children: [{ name: 'Tech', value: 20 }] }].",
     )
     .nonempty({ message: "Treemap chart data cannot be empty." }),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,

--- a/src/charts/word-cloud.ts
+++ b/src/charts/word-cloud.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "../utils";
-import { HeightSchema, TitleSchema, WidthSchema } from "./base";
+import { HeightSchema, ThemeSchema, TitleSchema, WidthSchema } from "./base";
 
 // Word cloud data schema
 const data = z.object({
@@ -16,6 +16,7 @@ const schema = z.object({
       "Data for word cloud chart, such as, [{ value: '4.272', text: '形成' }].",
     )
     .nonempty({ message: "Word cloud chart data cannot be empty." }),
+  theme: ThemeSchema,
   width: WidthSchema,
   height: HeightSchema,
   title: TitleSchema,


### PR DESCRIPTION
- feat: add academy theme
- ref https://github.com/antvis/GPT-Vis/pull/95
- ref https://github.com/antvis/mcp-server-chart/issues/25

![image](https://github.com/user-attachments/assets/a407465b-8714-48da-92ba-770c06817e42)

![image](https://github.com/user-attachments/assets/2dd93d66-d4f9-4f6d-9735-6968aafacac4)

