### PR TITLE
增加nginx有前缀的情况下，带着自定义转发名称，无法请求的问题

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,3 @@
+export const config = {
+  BASE_ENDPOINT: "/mcp-charts",
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
+import { config } from "./config";
 import {
   runHTTPStreamableServer,
   runSSEServer,
@@ -53,7 +54,7 @@ const transport = values.transport.toLowerCase();
 if (transport === "sse") {
   const port = Number.parseInt(values.port as string, 10);
   // Use provided endpoint or default to "/sse" for SSE
-  const endpoint = values.endpoint || "/sse";
+  const endpoint = values.endpoint || `${config.BASE_ENDPOINT}/sse`;
   runSSEServer(endpoint, port).catch(console.error);
 } else if (transport === "streamable") {
   const port = Number.parseInt(values.port as string, 10);

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import * as Charts from "./charts";
+import { config } from "./config";
 import {
   startHTTPStreamableServer,
   startSSEMcpServer,
@@ -110,7 +111,7 @@ export async function runStdioServer(): Promise<void> {
  * Runs the server with SSE transport.
  */
 export async function runSSEServer(
-  endpoint = "/sse",
+  endpoint = `${config.BASE_ENDPOINT}/sse`,
   port = 1122,
 ): Promise<void> {
   const server = createServer();

--- a/src/services/sse.ts
+++ b/src/services/sse.ts
@@ -1,11 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { config } from "../config";
 import { type RequestHandlers, createBaseHttpServer } from "../utils";
 
 export const startSSEMcpServer = async (
   server: Server,
-  endpoint = "/sse",
+  endpoint = `${config.BASE_ENDPOINT}/sse`,
   port = 1122,
 ): Promise<void> => {
   const activeTransports: Record<string, SSEServerTransport> = {};
@@ -24,7 +25,10 @@ export const startSSEMcpServer = async (
 
     // Handle GET requests to the SSE endpoint
     if (req.method === "GET" && reqUrl.pathname === endpoint) {
-      const transport = new SSEServerTransport("/messages", res);
+      const transport = new SSEServerTransport(
+        `${config.BASE_ENDPOINT}/messages`,
+        res,
+      );
 
       activeTransports[transport.sessionId] = transport;
 
@@ -62,7 +66,10 @@ export const startSSEMcpServer = async (
     }
 
     // Handle POST requests to the messages endpoint
-    if (req.method === "POST" && req.url?.startsWith("/messages")) {
+    if (
+      req.method === "POST" &&
+      req.url?.startsWith(`${config.BASE_ENDPOINT}/messages`)
+    ) {
       const sessionId = new URL(
         req.url,
         "https://example.com",

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -1,5 +1,6 @@
 import http from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { config } from "../config";
 
 /**
  * Interface for request handlers that will be passed to the server factory
@@ -51,12 +52,12 @@ function handleCommonEndpoints(
     return true;
   }
 
-  if (req.method === "GET" && req.url === "/health") {
+  if (req.method === "GET" && req.url === `${config.BASE_ENDPOINT}/health`) {
     res.writeHead(200, { "Content-Type": "text/plain" }).end("OK");
     return true;
   }
 
-  if (req.method === "GET" && req.url === "/ping") {
+  if (req.method === "GET" && req.url === `${config.BASE_ENDPOINT}/ping`) {
     res.writeHead(200).end("pong");
     return true;
   }
@@ -96,8 +97,8 @@ function logServerStartup(
   endpoint: string,
 ): void {
   const serverUrl = `http://localhost:${port}${endpoint}`;
-  const healthUrl = `http://localhost:${port}/health`;
-  const pingUrl = `http://localhost:${port}/ping`;
+  const healthUrl = `http://localhost:${port}${config.BASE_ENDPOINT}/health`;
+  const pingUrl = `http://localhost:${port}${config.BASE_ENDPOINT}/ping`;
 
   console.log(
     `${serverType} running on: \x1b[32m\u001B[4m${serverUrl}\u001B[0m\x1b[0m`,


### PR DESCRIPTION
目前项目启动起来是http://locahost:1122/sse 这样的。很多情况下是内网部署，并不会开通1122端口。
如果进行域名映射，nginx的配置，会加一层域名路径，变成类似于这样https://a.com/mcp-charts/sse 。此时client无法调通这个server服务。
此更改加入域名前缀配置，这样项目启动起来就是http://locahost:1122/mcp-charts/sse。 再通过https://a.com/mcp-charts/sse 这样映射出来，mcp-client就可以调用成功。
大神看看有没有必要，如果有必要，希望提出更优雅的写法。
```
location /mcp-charts/
{
    proxy_pass http://127.0.0.1:1122/;
    #proxy_set_header Host $host;
    #proxy_set_header X-Real-IP $remote_addr;
    #proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    #proxy_set_header REMOTE-HOST $remote_addr;
    #proxy_set_header Upgrade $http_upgrade;

    proxy_http_version 1.1;
    proxy_set_header Connection '';
    proxy_buffering off;
    proxy_cache off;
    proxy_read_timeout 86400;

    #add_header X-Cache $upstream_cache_status;

}
```
