### PR TITLE
Feat: Add support for uploading generated images to MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,45 @@ Options:
 
 You can use AntV's project [GPT-Vis-SSR](https://github.com/antvis/GPT-Vis/tree/main/bindings/gpt-vis-ssr) to deploy an HTTP service in a private environment, and then pass the URL address through env `VIS_REQUEST_SERVER`.
 
+You can also choose to upload the image to your MinIO server by configuring the following environment variables:
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-chart": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@antv/mcp-server-chart"
+      ],
+      "env": {
+        "VIS_GENERATE_STRATEGY": "minio",
+        "MINIO_ENDPOINT": "<YOUR_MINIO_ENDPOINT>",
+        "MINIO_PORT": "<YOUR_MINIO_PORT>",
+        "MINIO_USE_SSL": "<USE_SSL>",
+        "MINIO_ACCESS_KEY": "<YOUR_MINIO_ACCESS_KEY>",
+        "MINIO_SECRET_KEY": "<YOUR_MINIO_SECRET_KEY>",
+        "MINIO_BUCKET_NAME": "<YOUR_MINIO_BUCKET_NAME>",
+        "MINIO_USE_PUBLIC_BUCKET": "<USE_PUBLIC_BUCKET>"
+      }
+    }
+  }
+}
+```
+
+- `VIS_GENERATE_STRATEGY`: Specifies the image service strategy.
+  - Default: `antvis`
+  - Available values: `antvis` | `minio`
+  - Note: If using `minio`, you must configure the MINIO_xxx variables below.
+- `MINIO_ENDPOINT`: The address of the MinIO server (without port). Default: `127.0.0.1`.
+- `MINIO_PORT`: The port of the MinIO server. Default: `9000`.
+- `MINIO_USE_SSL`: Whether to use SSL for the MinIO server. Default: `false`.
+- `MINIO_ACCESS_KEY`: The access key for connecting to the MinIO server. Default: `minio`.
+- `MINIO_SECRET_KEY`: The secret key for connecting to the MinIO server. Default: `minioadmin`.
+- `MINIO_BUCKET_NAME`: The bucket used for uploads. If the bucket does not exist, it will be created automatically. Default: `mcp-server-chart`.
+- `MINIO_USE_PUBLIC_BUCKET`: Whether the bucket should allow public access. Default: `true`.
+- `MINIO_OBJECT_EXPIRY_SECONDS`: If `MINIO_USE_PUBLIC_BUCKET` is false, this sets the expiration time (in seconds) for objects. Default: 3600.
+
 - **Method**: `POST`
 - **Parameter**: Which will be passed to `GPT-Vis-SSR` for renderring. Such as, `{ "type": "line", "data": [{ "time": "2025-05", "value": "512" }, { "time": "2025-06", "value": "1024" }] }`.
 - **Return**: The return object of HTTP service.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/mcp-server-chart",
   "description": "A Model Context Protocol server for generating charts using AntV, This is a TypeScript-based MCP server that provides chart generation capabilities. It allows you to create various types of charts through MCP tools.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "exports": {
@@ -26,8 +26,15 @@
   "bin": {
     "mcp-server-chart": "./build/index.js"
   },
-  "files": ["build"],
-  "keywords": ["antv", "mcp", "data-visualization", "chart"],
+  "files": [
+    "build"
+  ],
+  "keywords": [
+    "antv",
+    "mcp",
+    "data-visualization",
+    "chart"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/antvis/mcp-server-chart"
@@ -38,8 +45,12 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@antv/gpt-vis-ssr": "^0.1.6",
     "@modelcontextprotocol/sdk": "^1.11.4",
     "axios": "^1.9.0",
+    "canvas": "^3.1.0",
+    "minio": "^8.0.5",
+    "uuid": "^11.1.0",
     "zod": "^3.25.16",
     "zod-to-json-schema": "^3.24.5"
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: "mcp-server-chart",
-      version: "0.6.1",
+      version: "0.6.2",
     },
     {
       capabilities: {

--- a/src/utils/GenerateStrategy.ts
+++ b/src/utils/GenerateStrategy.ts
@@ -1,0 +1,55 @@
+import { generateChartUrl as antvisGenerate } from "./generate";
+import { MinioGenerator } from "./generateMinio";
+
+enum GenerateStrategyType {
+  Antvis = "ANTVIS",
+  Minio = "MINIO",
+}
+
+interface GenerateStrategy {
+  generate(type: string, options: Record<string, any>): Promise<string>;
+}
+
+class AntvisGenerateStrategy implements GenerateStrategy {
+  async generate(
+    type: string,
+    options: Record<string, any>,
+  ): Promise<string> {
+    return await antvisGenerate(type, options);
+  }
+}
+
+class MinioGenerateStrategy implements GenerateStrategy {
+  async generate(
+    type: string,
+    options: Record<string, any>,
+  ): Promise<string> {
+    const minioGenerator = MinioGenerator.getInstance();
+    return await minioGenerator.generate(type, options);
+  }
+}
+
+const strategies: Record<GenerateStrategyType, GenerateStrategy> = {
+  [GenerateStrategyType.Antvis]: new AntvisGenerateStrategy(),
+  [GenerateStrategyType.Minio]: new MinioGenerateStrategy(),
+};
+
+export function getStrategy(type: string): GenerateStrategy {
+  const matchedStrategyType = Object.keys(GenerateStrategyType).find(
+    (key) => key.toLowerCase() === type.toLowerCase(),
+  );
+
+  if (matchedStrategyType) {
+    const enumValue =
+      GenerateStrategyType[
+        matchedStrategyType as keyof typeof GenerateStrategyType
+      ];
+    return strategies[enumValue];
+  }
+
+  throw new Error(
+    `Strategy "${type}" not found. Available strategies: ${Object.values(
+      GenerateStrategyType,
+    ).join(", ")}`,
+  );
+}

--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -1,7 +1,8 @@
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import * as Charts from "../charts";
-import { generateChartUrl } from "./generate";
+import { getStrategy } from "./GenerateStrategy";
+import { getVisGenerateStrategy } from "./env";
 import { ValidateError } from "./validator";
 
 // Chart type mapping
@@ -59,7 +60,8 @@ export async function callTool(tool: string, args: object = {}) {
       }
     }
 
-    const url = await generateChartUrl(chartType, args);
+    const generateStrategy = getStrategy(getVisGenerateStrategy());
+    const url = await generateStrategy.generate(chartType, args);
 
     return {
       content: [

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,11 @@
 /**
+ * Get the VIS_GENERATE_STRATEGY from environment variables.
+ */
+export function getVisGenerateStrategy() {
+  return process.env.VIS_GENERATE_STRATEGY || "antvis";
+}
+
+/**
  * Get the VIS_REQUEST_SERVER from environment variables.
  */
 export function getVisRequestServer() {
@@ -6,4 +13,116 @@ export function getVisRequestServer() {
     process.env.VIS_REQUEST_SERVER ||
     "https://antv-studio.alipay.com/api/gpt-vis"
   );
+}
+
+/**
+ * Get the MINIO_ENDPOINT from environment variables.
+ */
+export function getMinioEndpoint() {
+  return process.env.MINIO_ENDPOINT || "127.0.0.1";
+}
+
+/**
+ * Get the MINIO_PORT from environment variables.
+ */
+export function getMinioPort(): number {
+  const envPort = process.env.MINIO_PORT;
+
+  if (!envPort) {
+    return 9000;
+  }
+
+  const port = Number.parseInt(envPort, 10);
+
+  if (Number.isNaN(port)) {
+    throw new Error(`Invalid MINIO_PORT: "${envPort}" must be a number`);
+  }
+
+  if (port < 1 || port > 65535) {
+    throw new Error(`Invalid MINIO_PORT: ${port} must be between 1 and 65535`);
+  }
+
+  return port;
+}
+
+/**
+ * Get the MINIO_USE_SSL from environment variables.
+ */
+export function getMinioUseSSL(): boolean {
+  return getBooleanFromEnv("MINIO_USE_SSL");
+}
+
+/**
+ * Get the MINIO_ACCESS_KEY from environment variables.
+ */
+export function getMinioAccessKey() {
+  return process.env.MINIO_ACCESS_KEY || "minio";
+}
+
+/**
+ * Get the MINIO_SECRET_KEY from environment variables.
+ */
+export function getMinioSecretsKey() {
+  return process.env.MINIO_SECRET_KEY || "minioadmin";
+}
+
+/**
+ * Get the MINIO_BUCKET_NAME from environment variables.
+ */
+export function getMinioBucketName() {
+  return process.env.MINIO_BUCKET_NAME || "mcp-server-chart";
+}
+
+/**
+ * Get the MINIO_USE_PUBLIC_BUCKET from environment variables.
+ */
+export function getMinioUsePublicBucket(): boolean {
+  return getBooleanFromEnv("MINIO_USE_PUBLIC_BUCKET");
+}
+
+/**
+ * Get the MINIO_OBJECT_EXPIRY_SECONDS from environment variables.
+ */
+export function getMinioObjectExpirySeconds(): number {
+  const envPort = process.env.MINIO_OBJECT_EXPIRY_SECONDS;
+
+  if (!envPort) {
+    return 3600;
+  }
+
+  const port = Number.parseInt(envPort, 10);
+
+  if (Number.isNaN(port)) {
+    throw new Error(
+      `Invalid MINIO_OBJECT_EXPIRY_SECONDS: "${envPort}" must be a number`,
+    );
+  }
+
+  if (port < 0) {
+    throw new Error(
+      `Invalid MINIO_OBJECT_EXPIRY_SECONDS: ${port} must larger then 0`,
+    );
+  }
+
+  return port;
+}
+
+function getBooleanFromEnv(envKey: string): boolean {
+  const envValue = process.env[envKey];
+
+  if (envValue === undefined || envValue === "") {
+    return false;
+  }
+
+  const normalized = envValue.trim().toLowerCase();
+
+  if (["true", "1", "yes", "y", "on"].includes(normalized)) {
+    return true;
+  }
+
+  if (["false", "0", "no", "n", "off"].includes(normalized)) {
+    return false;
+  }
+
+  throw new Error(`Invalid boolean value for ${envKey}: "${envValue}"`);
 }

--- a/src/utils/generateMinio.ts
+++ b/src/utils/generateMinio.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs";
+import path from "node:path";
+import { render } from "@antv/gpt-vis-ssr";
+import type { Options } from "@antv/gpt-vis-ssr/dist/esm/types";
+import { Client } from "minio";
+import { v4 as uuidv4 } from "uuid";
+import {
+  getMinioAccessKey,
+  getMinioBucketName,
+  getMinioEndpoint,
+  getMinioObjectExpirySeconds,
+  getMinioPort,
+  getMinioSecretsKey,
+  getMinioUsePublicBucket,
+  getMinioUseSSL,
+} from "./env";
+
+class MinioGenerator {
+  private static instance: MinioGenerator;
+  private endpoint: string;
+  private port: number;
+  private useSSL: boolean;
+  private accessKey: string;
+  private secretsKey: string;
+  private usePublicBucket: boolean;
+  private objectExpirySeconds: number;
+  private bucketName: string;
+  private minioClient?: Client;
+
+  private constructor() {
+    this.endpoint = getMinioEndpoint();
+    this.port = getMinioPort();
+    this.useSSL = getMinioUseSSL();
+    this.accessKey = getMinioAccessKey();
+    this.secretsKey = getMinioSecretsKey();
+    this.usePublicBucket = getMinioUsePublicBucket();
+    this.objectExpirySeconds = getMinioObjectExpirySeconds();
+    this.bucketName = getMinioBucketName();
+  }
+
+  static getInstance(): MinioGenerator {
+    if (!MinioGenerator.instance) {
+      MinioGenerator.instance = new MinioGenerator();
+    }
+    return MinioGenerator.instance;
+  }
+
+  async generate(
+    type: string,
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    options: Record<string, any>,
+  ): Promise<string> {
+    await this.initBucket();
+    const filePath = await this.generateChartFile(type, options);
+    return await this.uploadToMinio(filePath);
+  }
+
+  private async initClient() {
+    if (!this.minioClient) {
+      this.minioClient = new Client({
+        endPoint: this.endpoint,
+        port: this.port,
+        useSSL: this.useSSL,
+        accessKey: this.accessKey,
+        secretKey: this.secretsKey,
+      });
+    }
+  }
+
+  private async initBucket() {
+    try {
+      await this.initClient();
+      const bucketExists = await this.minioClient?.bucketExists(
+        this.bucketName,
+      );
+      if (!bucketExists) {
+        await this.minioClient?.makeBucket(this.bucketName);
+        console.log(`Bucket "${this.bucketName}" created.`);
+      }
+      if (this.usePublicBucket) {
+        await this.minioClient?.setBucketPolicy(
+          this.bucketName,
+          JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: "*",
+                Action: ["s3:GetObject"],
+                Resource: [`arn:aws:s3:::${this.bucketName}/*`],
+              },
+            ],
+          }),
+        );
+      }
+    } catch (err) {
+      console.error("Error:", err);
+    }
+  }
+
+  private async generateChartFile(
+    type: string,
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    options: Record<string, any>,
+  ): Promise<string> {
+    const reqOptions = {
+      type,
+      ...options,
+      source: "mcp-server-chart",
+    } as unknown as Options;
+    const vis = await render(reqOptions);
+    const buffer = await vis.toBuffer();
+    const filename = `${uuidv4()}.png`;
+
+    const imageDir = path.join(__dirname, "images");
+    if (!fs.existsSync(imageDir)) {
+      fs.mkdirSync(imageDir);
+    }
+
+    const filePath = path.join(imageDir, filename);
+    fs.writeFileSync(filePath, buffer);
+
+    return filePath;
+  }
+
+  private async uploadToMinio(filePath: string): Promise<string> {
+    const objectName = path.basename(filePath);
+
+    try {
+      await this.minioClient?.fPutObject(
+        this.bucketName,
+        objectName,
+        filePath,
+        {
+          "Content-Type": "image/jpeg",
+        },
+      );
+
+      console.log(
+        `File uploaded successfully to ${this.bucketName}/${objectName}`,
+      );
+
+      let url: string | undefined;
+      if (this.usePublicBucket) {
+        url = `${this.useSSL ? "https" : "http"}://${this.endpoint}:${
+          this.port
+        }/${this.bucketName}/${objectName}`;
+      } else {
+        url = await this.minioClient?.presignedGetObject(
+          this.bucketName,
+          objectName,
+          this.objectExpirySeconds,
+        );
+        url = this.useSSL
+          ? url?.replace("http://", "https://")
+          : url?.replace("https://", "http://");
+      }
+
+      if (!url) {
+        throw Error(
+          `Get url form minio failed: bucketName: ${this.bucketName}, objectName: ${objectName}`,
+        );
+      }
+
+      console.log("Presigned URL:", url);
+
+      try {
+        fs.unlinkSync(filePath);
+      } catch (err) {
+        console.error("delete file failed:", err);
+      }
+      return url;
+    } catch (err) {
+      console.error("Error:", err);
+      throw err;
+    }
+  }
+}
+
+export { MinioGenerator };


### PR DESCRIPTION
We have now added a new option to support uploading generated images to MinIO. Simply set the environment variable VIS_GENERATE_STRATEGY to "minio" to enable this feature.

The implementation uses the Strategy Pattern to ensure extensibility, with the following key characteristics:

The original functionality remains completely unchanged

The default strategy maintains backward compatibility

All existing tests pass successfully

The feature demonstrates stable performance in testing

We sincerely hope the maintainers will consider accepting and merging this contribution.