### PR TITLE
Dev/add spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,19 @@ Start the MCP server:
 npm run start
 ```
 
+Start the MCP server with SSE transport:
+
+```bash
+node build/index.js -t sse
+```
+
+Start the MCP server with Streamable transport:
+
+```bash
+node build/index.js -t streamable
+```
+
+
 ## 📄 License
 
 MIT@[AntV](https://github.com/antvis).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/mcp-server-chart",
   "description": "A Model Context Protocol server for generating charts using AntV. This is a TypeScript-based MCP server that provides chart generation capabilities. It allows you to create various types of charts through MCP tools.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "exports": {

--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -67,10 +67,10 @@ export async function callTool(tool: string, args: object = {}) {
       "generate_path_map",
       "generate_pin_map",
     ].includes(tool);
+
     if (isMapChartTool) {
       // For map charts, we use the generateMap function, and return the mcp result.
       const { metadata, ...result } = await generateMap(tool, args);
-
       return result;
     }
 
@@ -83,6 +83,11 @@ export async function callTool(tool: string, args: object = {}) {
           text: url,
         },
       ],
+      _meta: {
+        description:
+          "Charts spec configuration, you can use this config to generate the corresponding chart.",
+        spec: { type: chartType, ...args },
+      },
     };
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   } catch (error: any) {


### PR DESCRIPTION
mcp 输出增加 _meta 内容，包括：
生成图表的 spec 数据，该 spec 为 mcp-server-chart 以及 GPT-Vis 的入参，使用其可直接生成图表。

输出参数如下：
```json
{
  "success":true,
  "data": {
    "_meta": {
       "description":"Charts spec configuration, you can use this config to generate the corresponding chart.",
        "spec": {
         "type": "liquid",
        "percent": 0.65
       }
    },
    "content": [
      {
        "type": "text",
        "text": "https://",
      }
    ]
  }
}
```
