### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,3 +285,8 @@ node build/index.js -t streamable
 ## 📄 License
 
 MIT@[AntV](https://github.com/antvis).
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/antv-mcp-server-chart).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/antv-mcp-server-chart).