### PR TITLE
fix: return isError instead of throwing InternalError on chart failures

### DIFF
--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -108,15 +108,23 @@ export async function callTool(tool: string, args: object = {}) {
     };
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   } catch (error: any) {
-    logger.error(
-      `Failed to generate chart: ${error.message || "Unknown error"}.`,
-    );
+    const message = error?.message || "Unknown error";
+    logger.error(`Failed to generate chart: ${message}.`);
     if (error instanceof McpError) throw error;
     if (error instanceof ValidateError)
       throw new McpError(ErrorCode.InvalidParams, error.message);
-    throw new McpError(
-      ErrorCode.InternalError,
-      `Failed to generate chart: ${error?.message || "Unknown error."}`,
-    );
+    // Return isError content instead of throwing InternalError (-32603).
+    // InternalError is treated as a server crash by MCP clients; agents
+    // cannot recover from it. Returning isError: true with a descriptive
+    // message lets agents self-correct (e.g., fix their input and retry).
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to generate chart: ${message}. Please check that the data matches the expected format for this chart type.`,
+        },
+      ],
+      isError: true,
+    };
   }
 }


### PR DESCRIPTION
## Summary

- When chart rendering fails (e.g., due to invalid/empty data), the catch block in `callTool.ts` threw `McpError(InternalError)` which maps to MCP error -32603
- MCP clients treat -32603 as a server crash, so agents receive raw stack traces and cannot recover or self-correct
- Changed to return `{ content: [...], isError: true }` with a descriptive error message
- `McpError` and `ValidateError` are still thrown as before (they produce proper MCP error responses)

## Tools fixed

All 9 tools from #291: `generate_fishbone_diagram`, `generate_mind_map`, `generate_organization_chart`, `generate_flow_diagram`, `generate_network_graph`, `generate_funnel_chart`, `generate_venn_chart`, `generate_district_map`, `generate_radar_chart`

## Before/After

**Before:** Agent receives `-32603` with a raw stack trace:
```
internal error: MCP error -32603: Failed to generate chart: Cannot read properties of undefined (reading 'category')
TypeError: Cannot read properties of undefined (reading 'category')
    at _callee$ (/var/task/code/font.ts:40:2)
    ...
```

**After:** Agent receives `isError: true` with actionable message:
```json
{
  "content": [{"type": "text", "text": "Failed to generate chart: Cannot read properties of undefined (reading 'category'). Please check that the data matches the expected format for this chart type."}],
  "isError": true
}
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] biome lint passes (ran via pre-commit hook)
- [x] Verified with [mcp-assert](https://github.com/blackwell-systems/mcp-assert)

Fixes #291