### PR TITLE
fix(callTool): address bot review comments on PR #296

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,17 @@ You can disable specific chart generation tools using the `DISABLED_TOOLS` envir
 
 **Available tool names for filtering** See the [✨ Features](#-features).
 
+## ⚠️ Security Considerations
+
+When using chart data from external sources (APIs, databases, CSV files), be aware of **Prompt Injection** risks. Malicious data in field values, labels, or titles can potentially affect AI assistant behavior.
+
+**Recommendations:**
+- Validate and sanitize external data before use
+- Set reasonable length limits on text fields
+- Do not blindly trust chart outputs from untrusted data sources
+
+For more details, see [Security Advisory #279](https://github.com/antvis/mcp-server-chart/issues/279).
+
 ## 🔨 Development
 
 Install dependencies:

--- a/src/charts/flow-diagram.ts
+++ b/src/charts/flow-diagram.ts
@@ -17,7 +17,9 @@ const schema = {
       nodes: z
         .array(NodeSchema)
         .nonempty({ message: "At least one node is required." }),
-      edges: z.array(EdgeSchema),
+      edges: z
+        .array(EdgeSchema)
+        .nonempty({ message: "At least one edge is required." }),
     })
     .describe(
       "Data for flow diagram chart, such as, { nodes: [{ name: 'node1' }, { name: 'node2' }], edges: [{ source: 'node1', target: 'node2', name: 'edge1' }] }.",

--- a/src/charts/network-graph.ts
+++ b/src/charts/network-graph.ts
@@ -17,7 +17,9 @@ const schema = {
       nodes: z
         .array(NodeSchema)
         .nonempty({ message: "At least one node is required." }),
-      edges: z.array(EdgeSchema),
+      edges: z
+        .array(EdgeSchema)
+        .nonempty({ message: "At least one edge is required." }),
     })
     .describe(
       "Data for network graph chart, such as, { nodes: [{ name: 'node1' }, { name: 'node2' }], edges: [{ source: 'node1', target: 'node2', name: 'edge1' }] }",

--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -36,6 +36,27 @@ const CHART_TYPE_MAP = {
   generate_spreadsheet: "spreadsheet",
 } as const;
 
+// Line/area charts use time-based x-axis that needs chronological sorting
+const TIME_BASED_CHARTS = ["generate_line_chart", "generate_area_chart"];
+
+/**
+ * Sort line/area chart data by time field to ensure x-axis labels are chronological.
+ * ISO-8601 date strings (e.g., "2026-01", "2026-03") sort correctly as strings.
+ */
+function sortTimeBasedData(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!Array.isArray(args.data)) {
+    return args;
+  }
+  const sortedData = [...args.data].sort((a, b) => {
+    const timeA = (a as { time?: string }).time ?? "";
+    const timeB = (b as { time?: string }).time ?? "";
+    return timeA.localeCompare(timeB);
+  });
+  return { ...args, data: sortedData };
+}
+
 // Pre-compile Zod schemas at module load time to avoid recompiling on every request.
 // biome-ignore lint/suspicious/noExplicitAny: schema types vary per chart
 const COMPILED_SCHEMA_CACHE = new Map<string, z.ZodObject<any>>();
@@ -84,13 +105,18 @@ export async function callTool(tool: string, args: object = {}) {
       "generate_pin_map",
     ].includes(tool);
 
+    // Sort time-based chart data to ensure x-axis labels are chronological
+    const sortedArgs = TIME_BASED_CHARTS.includes(tool)
+      ? sortTimeBasedData(args as Record<string, unknown>)
+      : (args as Record<string, unknown>);
+
     if (isMapChartTool) {
       // For map charts, we use the generateMap function, and return the mcp result.
-      const { metadata, ...result } = await generateMap(tool, args);
+      const { metadata, ...result } = await generateMap(tool, sortedArgs);
       return result;
     }
 
-    const url = await generateChartUrl(chartType, args);
+    const url = await generateChartUrl(chartType, sortedArgs);
     logger.info(`Generated chart URL: ${url}`);
 
     return {

--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -91,11 +91,16 @@ export async function callTool(tool: string, args: object = {}) {
       // Use safeParse instead of parse and try-catch.
       const result = compiledSchema.safeParse(args);
       if (!result.success) {
-        logger.error(`Invalid parameters: ${result.error.message}`);
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          `Invalid parameters: ${result.error.message}`,
-        );
+        // ZodError.message includes stack trace in Zod v4; use issues for clean messages
+        const cleanMessage = result.error.issues
+          .map((issue) =>
+            issue.path.length > 0
+              ? `${issue.path.join(".")}: ${issue.message}`
+              : issue.message,
+          )
+          .join("; ");
+        logger.error(`Invalid parameters: ${cleanMessage}`);
+        throw new McpError(ErrorCode.InvalidParams, cleanMessage);
       }
     }
 
@@ -129,24 +134,11 @@ export async function callTool(tool: string, args: object = {}) {
       _meta: {
         description:
           "The content returned by MCP is the remote image URL of the visualization chart, which can be rendered using Markdown or HTML image tags. The _meta.spec content corresponds to the chart's configuration and spec, which can be rendered using AntV GPT-Vis chart components.",
-        spec: { type: chartType, ...args },
+        spec: { type: chartType, ...sortedArgs },
       },
     };
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   } catch (error: any) {
-    // ZodError.message includes stack trace in Zod v4; use issues for clean messages
-    if (error instanceof z.ZodError) {
-      const cleanMessage = error.issues
-        // biome-ignore lint/suspicious/noExplicitAny: ZodIssue type is complex; using any for brevity
-        .map((issue: any) =>
-          issue.path.length > 0
-            ? `${issue.path.join(".")}: ${issue.message}`
-            : issue.message,
-        )
-        .join("; ");
-      logger.error(`Invalid parameters: ${cleanMessage}`);
-      throw new McpError(ErrorCode.InvalidParams, cleanMessage);
-    }
     logger.error(
       `Failed to generate chart: ${error.message || "Unknown error"}.`,
     );

--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -108,6 +108,19 @@ export async function callTool(tool: string, args: object = {}) {
     };
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   } catch (error: any) {
+    // ZodError.message includes stack trace in Zod v4; use issues for clean messages
+    if (error instanceof z.ZodError) {
+      const cleanMessage = error.issues
+        // biome-ignore lint/suspicious/noExplicitAny: ZodIssue type is complex; using any for brevity
+        .map((issue: any) =>
+          issue.path.length > 0
+            ? `${issue.path.join(".")}: ${issue.message}`
+            : issue.message,
+        )
+        .join("; ");
+      logger.error(`Invalid parameters: ${cleanMessage}`);
+      throw new McpError(ErrorCode.InvalidParams, cleanMessage);
+    }
     logger.error(
       `Failed to generate chart: ${error.message || "Unknown error"}.`,
     );

--- a/src/utils/callTool.ts
+++ b/src/utils/callTool.ts
@@ -50,8 +50,8 @@ function sortTimeBasedData(
     return args;
   }
   const sortedData = [...args.data].sort((a, b) => {
-    const timeA = (a as { time?: string }).time ?? "";
-    const timeB = (b as { time?: string }).time ?? "";
+    const timeA = String((a as { time?: unknown }).time ?? "");
+    const timeB = String((b as { time?: unknown }).time ?? "");
     return timeA.localeCompare(timeB);
   });
   return { ...args, data: sortedData };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES6",
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Addressed bot review comments on PR #296:

1. **Comment #3158070918**: Fixed `_meta.spec` to use `sortedArgs` instead of original `args` for metadata consistency
2. **Comment #3158070922**: Moved ZodError clean message formatting to the `safeParse` result handler and removed unreachable catch block

### Changes

- `sortedArgs` is now used in `_meta.spec` to ensure metadata reflects sorted data
- ZodError formatting logic moved to where `!result.success` is handled (safeParse doesn't throw)
- Removed unreachable `if (error instanceof z.ZodError)` branch in catch block

## Test plan

- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)