### PR TITLE
Fix edge pair validation for hyphenated node names

### DIFF
--- a/__tests__/utils/validator.spec.ts
+++ b/__tests__/utils/validator.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import * as Charts from "../../src/charts";
+import { validatedNodeEdgeDataSchema } from "../../src/utils/validator";
 import { FlowDiagramSchema, MindMapSchema } from "../constant";
 
 describe("validator", () => {
@@ -20,5 +21,17 @@ describe("validator", () => {
     }).toThrow(
       "Invalid parameters: edge pair 'KnowledgeBase-Model' should be unique.",
     );
+  });
+
+  it("should distinguish edge pairs when node names contain hyphens", () => {
+    expect(() =>
+      validatedNodeEdgeDataSchema({
+        nodes: [{ name: "a-b" }, { name: "a" }, { name: "b-c" }, { name: "c" }],
+        edges: [
+          { name: "edge 1", source: "a-b", target: "c" },
+          { name: "edge 2", source: "a", target: "b-c" },
+        ],
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -58,7 +58,7 @@ export const validatedNodeEdgeDataSchema = (data: NodeEdgeDataType) => {
   // 3. valid edge source edge target pair are unique
   const edgePairs = new Set();
   for (const edge of data.edges) {
-    const pairKey = JSON.stringify([edge.source, edge.target]);
+    const pairKey = `${edge.source}\0${edge.target}`;
     if (edgePairs.has(pairKey)) {
       throw new ValidateError(
         `Invalid parameters: edge pair '${edge.source}-${edge.target}' should be unique.`,

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -58,13 +58,13 @@ export const validatedNodeEdgeDataSchema = (data: NodeEdgeDataType) => {
   // 3. valid edge source edge target pair are unique
   const edgePairs = new Set();
   for (const edge of data.edges) {
-    const pair = `${edge.source}-${edge.target}`;
-    if (edgePairs.has(pair)) {
+    const pairKey = JSON.stringify([edge.source, edge.target]);
+    if (edgePairs.has(pairKey)) {
       throw new ValidateError(
-        `Invalid parameters: edge pair '${pair}' should be unique.`,
+        `Invalid parameters: edge pair '${edge.source}-${edge.target}' should be unique.`,
       );
     }
-    edgePairs.add(pair);
+    edgePairs.add(pairKey);
   }
 
   return true;


### PR DESCRIPTION
## Summary
- Use a structured edge-pair key when validating node-edge chart data.
- Add a regression test covering node names that contain hyphens.

## Why
The validator currently builds edge uniqueness keys with `${source}-${target}`. This collides for different edge pairs when node names themselves contain hyphens, for example `a-b -> c` and `a -> b-c` both become `a-b-c`. Those valid inputs are rejected as duplicate edges.

## Validation
- `npm test -- --run __tests__/utils/validator.spec.ts` (`3 passed`)
- `npm test -- --run` (`44 passed`)
- `npm run build`
- `npx biome check __tests__/utils/validator.spec.ts src/utils/validator.ts`
- `git diff --check`